### PR TITLE
fix: 修复自研被动光环被当作主动技能释放

### DIFF
--- a/server/src/battle/battleFactory.ts
+++ b/server/src/battle/battleFactory.ts
@@ -17,6 +17,7 @@ import { generateBattleSeed, getNextRandom } from './utils/random.js';
 import { getNormalAttack } from './modules/skill.js';
 import { normalizeRealmKeepingUnknown } from '../services/shared/realmRules.js';
 import type { PartnerSkillPolicySlotDto } from '../services/shared/partnerSkillPolicy.js';
+import { CHARACTER_RATIO_ATTR_KEY_SET } from '../services/shared/characterAttrRegistry.js';
 
 // 角色数据接口（来自数据库）
 export interface CharacterData {
@@ -41,6 +42,7 @@ export interface CharacterData {
   baoji: number;
   baoshang: number;
   jianbaoshang: number;
+  jianfantan: number;
   kangbao: number;
   zengshang: number;
   zhiliao: number;
@@ -84,6 +86,7 @@ export interface MonsterData {
     baoji?: number;
     baoshang?: number;
     jianbaoshang?: number;
+    jianfantan?: number;
     kangbao?: number;
     zengshang?: number;
     zhiliao?: number;
@@ -123,26 +126,9 @@ function clampNumber(value: number, min: number, max: number): number {
   return value;
 }
 
-const MONSTER_RATIO_ATTR_KEYS: ReadonlySet<keyof BattleAttrs> = new Set([
-  'mingzhong',
-  'shanbi',
-  'zhaojia',
-  'baoji',
-  'baoshang',
-  'jianbaoshang',
-  'kangbao',
-  'zengshang',
-  'zhiliao',
-  'jianliao',
-  'xixue',
-  'lengque',
-  'kongzhi_kangxing',
-  'jin_kangxing',
-  'mu_kangxing',
-  'shui_kangxing',
-  'huo_kangxing',
-  'tu_kangxing',
-]);
+const MONSTER_RATIO_ATTR_KEYS: ReadonlySet<keyof BattleAttrs> = new Set(
+  Array.from(CHARACTER_RATIO_ATTR_KEY_SET) as Array<keyof BattleAttrs>,
+);
 
 function applyMonsterEncounterScaling(state: BattleState, base: BattleAttrs, monster: MonsterData): BattleAttrs {
   const variance = clampNumber(toNumber(monster.attr_variance, 0.05), 0, 1);
@@ -166,6 +152,7 @@ function applyMonsterEncounterScaling(state: BattleState, base: BattleAttrs, mon
     'baoji',
     'baoshang',
     'jianbaoshang',
+    'jianfantan',
     'kangbao',
     'zengshang',
     'zhiliao',
@@ -217,6 +204,7 @@ export interface SkillData {
   damage_type: string;
   element: string;
   effects: SkillEffect[];
+  trigger_type?: 'active' | 'passive';
   ai_priority: number;
 }
 
@@ -470,6 +458,7 @@ function extractAttrs(data: CharacterData): BattleAttrs {
     baoji: data.baoji,
     baoshang: data.baoshang,
     jianbaoshang: data.jianbaoshang,
+    jianfantan: data.jianfantan,
     kangbao: data.kangbao,
     zengshang: data.zengshang,
     zhiliao: data.zhiliao,
@@ -509,6 +498,7 @@ function extractMonsterAttrs(data: MonsterData): BattleAttrs {
     baoji: toNumber(attrs.baoji, 0),
     baoshang: toNumber(attrs.baoshang, 0),
     jianbaoshang: toNumber(attrs.jianbaoshang, 0),
+    jianfantan: toNumber(attrs.jianfantan, 0),
     kangbao: toNumber(attrs.kangbao, 0),
     zengshang: toNumber(attrs.zengshang, 0),
     zhiliao: toNumber(attrs.zhiliao, 0),
@@ -548,7 +538,7 @@ function convertSkillData(data: SkillData): BattleSkill {
     damageType: data.damage_type as any,
     element: data.element || 'none',
     effects: data.effects || [],
-    triggerType: 'active',
+    triggerType: data.trigger_type === 'passive' ? 'passive' : 'active',
     aiPriority: data.ai_priority || 50,
   };
 }

--- a/server/src/services/__tests__/characterBattleSkillLoadout.test.ts
+++ b/server/src/services/__tests__/characterBattleSkillLoadout.test.ts
@@ -1,0 +1,134 @@
+/**
+ * 作用：
+ * - 校验战斗技能装载入口会保留 triggerType，并且把被动技能从技能槽依赖中解耦。
+ * - 这里只测纯函数，不涉及数据库，确保方案二的复用逻辑稳定。
+ *
+ * 输入/输出：
+ * - 输入：已装备功法、技能槽、技能定义映射、层级规则。
+ * - 输出：战斗技能条目数组，包含 `skillId / upgradeLevel / triggerType`。
+ *
+ * 数据流：
+ * - 装备功法与层级规则先解出“已解锁技能”和“升级次数”。
+ * - 主动技能只保留已装槽的 active。
+ * - 被动技能从已装备功法里直接补齐，不依赖技能槽。
+ *
+ * 边界条件与坑点：
+ * 1. 被动技能即使排进技能槽，也不能占用主动技能顺序。
+ * 2. 未装任何技能槽时，被动技能仍应进入战斗技能列表。
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import type { SkillDefConfig } from '../staticConfigLoader.js';
+import type { TechniqueLayerStaticRow } from '../shared/techniqueUpgradeRules.js';
+import {
+  buildCharacterBattleSkillEntries,
+  canEquipBattleSkillToSlot,
+} from '../shared/characterBattleSkillLoadout.js';
+
+const buildSkillDefMap = (): ReadonlyMap<string, SkillDefConfig> => {
+  const rows: SkillDefConfig[] = [
+    {
+      id: 'skill-active-moon-slash',
+      name: '月刃斩',
+      source_type: 'technique',
+      source_id: 'tech-mirror-moon',
+      trigger_type: 'active',
+      target_type: 'single_enemy',
+      target_count: 1,
+      damage_type: 'magic',
+      element: 'shui',
+      effects: [],
+      enabled: true,
+    },
+    {
+      id: 'skill-passive-mirror-aura',
+      name: '镜月常明',
+      source_type: 'technique',
+      source_id: 'tech-mirror-moon',
+      trigger_type: 'passive',
+      target_type: 'self',
+      target_count: 1,
+      damage_type: 'magic',
+      element: 'shui',
+      effects: [],
+      enabled: true,
+    },
+  ] as SkillDefConfig[];
+  return new Map(rows.map((row) => [row.id, row] as const));
+};
+
+const buildLayerRows = (): TechniqueLayerStaticRow[] => [
+  {
+    techniqueId: 'tech-mirror-moon',
+    layer: 1,
+    costSpiritStones: 0,
+    costExp: 0,
+    costMaterials: [],
+    passives: [],
+    unlockSkillIds: ['skill-active-moon-slash', 'skill-passive-mirror-aura'],
+    upgradeSkillIds: [],
+    requiredRealm: null,
+    layerDesc: '第一层',
+  },
+  {
+    techniqueId: 'tech-mirror-moon',
+    layer: 2,
+    costSpiritStones: 0,
+    costExp: 0,
+    costMaterials: [],
+    passives: [],
+    unlockSkillIds: [],
+    upgradeSkillIds: ['skill-active-moon-slash'],
+    requiredRealm: null,
+    layerDesc: '第二层',
+  },
+];
+
+test('主动技能保留槽位顺序，被动技能自动补入且不占主动槽', () => {
+  const result = buildCharacterBattleSkillEntries({
+    equippedTechniques: [{ techniqueId: 'tech-mirror-moon', currentLayer: 2 }],
+    slottedSkills: [
+      { skillId: 'skill-passive-mirror-aura', slotIndex: 1 },
+      { skillId: 'skill-active-moon-slash', slotIndex: 2 },
+    ],
+    skillDefs: buildSkillDefMap(),
+    layerRows: buildLayerRows(),
+  });
+
+  assert.deepEqual(result, [
+    {
+      skillId: 'skill-active-moon-slash',
+      upgradeLevel: 1,
+      triggerType: 'active',
+    },
+    {
+      skillId: 'skill-passive-mirror-aura',
+      upgradeLevel: 0,
+      triggerType: 'passive',
+    },
+  ]);
+});
+
+test('未装技能槽时，被动技能仍会进入战斗列表', () => {
+  const result = buildCharacterBattleSkillEntries({
+    equippedTechniques: [{ techniqueId: 'tech-mirror-moon', currentLayer: 1 }],
+    slottedSkills: [],
+    skillDefs: buildSkillDefMap(),
+    layerRows: buildLayerRows(),
+  });
+
+  assert.deepEqual(result, [
+    {
+      skillId: 'skill-passive-mirror-aura',
+      upgradeLevel: 0,
+      triggerType: 'passive',
+    },
+  ]);
+});
+
+test('passive skill cannot be equipped into battle slots', () => {
+  assert.equal(canEquipBattleSkillToSlot('active'), true);
+  assert.equal(canEquipBattleSkillToSlot('passive'), false);
+  assert.equal(canEquipBattleSkillToSlot(undefined), true);
+});

--- a/server/src/services/__tests__/passiveAuraBattleFlow.test.ts
+++ b/server/src/services/__tests__/passiveAuraBattleFlow.test.ts
@@ -1,0 +1,204 @@
+/**
+ * 作用：
+ * - 校验 passive 光环在战斗开始时自动生效，不会进入主动可释放技能池。
+ * - 用一条完整战斗链路同时覆盖方案一和方案二落地后的真实行为。
+ *
+ * 输入/输出：
+ * - 输入：带被动光环和主动伤害技的最小 PVE 战斗数据。
+ * - 输出：战斗开始后的单位状态、可用技能列表和 AI 选技结果。
+ *
+ * 数据流：
+ * - SkillData 进入 battleFactory 转成 BattleSkill。
+ * - BattleEngine.startBattle 自动执行 passive。
+ * - getAvailableSkills / AI 只能看到 active 技能。
+ *
+ * 边界条件与坑点：
+ * 1. 光环日志应该表现为 `aura` 结算，而不是角色把回合花在重新施法上。
+ * 2. 被动技能即使存在于 skills 中，也不能被 AI 选为正常行动。
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { createPVEBattle, type CharacterData, type MonsterData, type SkillData } from '../../battle/battleFactory.js';
+import { BattleEngine } from '../../battle/battleEngine.js';
+import { getAvailableSkills } from '../../battle/modules/skill.js';
+import { makeAIDecision } from '../../battle/modules/ai.js';
+
+const createPlayerData = (): CharacterData => ({
+  user_id: 1,
+  id: 101,
+  nickname: '镜主',
+  realm: '炼气',
+  sub_realm: null,
+  attribute_element: 'shui',
+  qixue: 1200,
+  max_qixue: 1200,
+  lingqi: 100,
+  max_lingqi: 100,
+  wugong: 80,
+  fagong: 220,
+  wufang: 80,
+  fafang: 120,
+  sudu: 150,
+  mingzhong: 0.95,
+  shanbi: 0,
+  zhaojia: 0,
+  baoji: 0,
+  baoshang: 1.5,
+  jianbaoshang: 0,
+  kangbao: 0,
+  zengshang: 0,
+  zhiliao: 0,
+  jianliao: 0,
+  xixue: 0,
+  lengque: 0,
+  kongzhi_kangxing: 0,
+  jin_kangxing: 0,
+  mu_kangxing: 0,
+  shui_kangxing: 0,
+  huo_kangxing: 0,
+  tu_kangxing: 0,
+  qixue_huifu: 0,
+  lingqi_huifu: 0,
+});
+
+const createMonster = (): MonsterData => ({
+  id: 'monster-sandbag',
+  name: '木桩妖',
+  realm: '炼气',
+  element: 'none',
+  base_attrs: {
+    qixue: 800,
+    max_qixue: 800,
+    lingqi: 0,
+    max_lingqi: 0,
+    wugong: 50,
+    fagong: 50,
+    wufang: 50,
+    fafang: 50,
+    sudu: 60,
+    mingzhong: 0.95,
+  },
+  exp_reward: 0,
+  silver_reward_min: 0,
+  silver_reward_max: 0,
+});
+
+const passiveAuraSkill: SkillData = {
+  id: 'skill-passive-mirror-aura',
+  name: '镜月常明',
+  cost_lingqi: 0,
+  cost_lingqi_rate: 0,
+  cost_qixue: 0,
+  cost_qixue_rate: 0,
+  cooldown: 0,
+  target_type: 'self',
+  target_count: 1,
+  damage_type: 'magic',
+  element: 'shui',
+  effects: [
+    {
+      type: 'buff',
+      buffKind: 'aura',
+      auraTarget: 'self',
+      auraEffects: [
+        { type: 'restore_lingqi', value: 8 },
+        {
+          type: 'buff',
+          buffKind: 'attr',
+          attrKey: 'fagong',
+          applyType: 'percent',
+          value: 0.08,
+          duration: 1,
+        },
+      ],
+    },
+    {
+      type: 'debuff',
+      buffKind: 'aura',
+      auraTarget: 'all_enemy',
+      auraEffects: [
+        {
+          type: 'debuff',
+          buffKind: 'attr',
+          attrKey: 'sudu',
+          applyType: 'flat',
+          value: 10,
+          duration: 1,
+        },
+      ],
+    },
+  ],
+  trigger_type: 'passive',
+  ai_priority: 90,
+};
+
+const activeStrikeSkill: SkillData = {
+  id: 'skill-active-water-strike',
+  name: '水月击',
+  cost_lingqi: 10,
+  cost_lingqi_rate: 0,
+  cost_qixue: 0,
+  cost_qixue_rate: 0,
+  cooldown: 0,
+  target_type: 'single_enemy',
+  target_count: 1,
+  damage_type: 'magic',
+  element: 'shui',
+  effects: [
+    {
+      type: 'damage',
+      valueType: 'flat',
+      value: 120,
+      damageType: 'magic',
+      element: 'shui',
+    },
+  ],
+  trigger_type: 'active',
+  ai_priority: 70,
+};
+
+test('被动光环开场自动生效，AI 只会选择主动技能', () => {
+  const battle = createPVEBattle(
+    'battle-passive-aura',
+    createPlayerData(),
+    [passiveAuraSkill, activeStrikeSkill],
+    [createMonster()],
+    { 'monster-sandbag': [] },
+  );
+
+  const engine = new BattleEngine(battle);
+  engine.startBattle();
+
+  const state = engine.getState();
+  const player = state.teams.attacker.units[0];
+  const enemy = state.teams.defender.units[0];
+  assert.ok(player);
+  assert.ok(enemy);
+
+  const auraSkill = player.skills.find((skill) => skill.id === 'skill-passive-mirror-aura');
+  const strikeSkill = player.skills.find((skill) => skill.id === 'skill-active-water-strike');
+  assert.equal(auraSkill?.triggerType, 'passive');
+  assert.equal(strikeSkill?.triggerType, 'active');
+
+  const auraBuffs = player.buffs.filter((buff) => buff.aura);
+  assert.equal(auraBuffs.length, 2);
+  assert.ok(auraBuffs.every((buff) => buff.remainingDuration === -1));
+
+  const availableSkills = getAvailableSkills(player);
+  assert.deepEqual(
+    availableSkills.map((skill) => skill.id),
+    ['skill-normal-attack', 'skill-active-water-strike'],
+  );
+
+  const aiDecision = makeAIDecision(state, player);
+  assert.equal(aiDecision.skill.id, 'skill-active-water-strike');
+
+  const auraLogs = state.logs.filter((log) => log.type === 'aura');
+  assert.ok(auraLogs.length >= 1);
+
+  const enemySpeedDebuff = enemy.buffs.find((buff) =>
+    buff.attrModifiers?.some((modifier) => modifier.attr === 'sudu' && modifier.value === -10),
+  );
+  assert.ok(enemySpeedDebuff);
+});

--- a/server/src/services/battle/shared/skills.ts
+++ b/server/src/services/battle/shared/skills.ts
@@ -36,6 +36,7 @@ import {
   toText,
   uniqueStringIds,
 } from "./helpers.js";
+import { normalizeBattleSkillTriggerType } from "../../shared/characterBattleSkillLoadout.js";
 
 // ------ 常量 ------
 
@@ -91,6 +92,7 @@ export function toBattleSkillData(row: SkillDefConfig): SkillData {
     damage_type: String(row.damage_type || "none"),
     element: String(row.element || "none"),
     effects: cloneSkillEffectList(row.effects),
+    trigger_type: normalizeBattleSkillTriggerType(row.trigger_type),
     ai_priority: Math.max(0, Math.floor(Number(row.ai_priority ?? 50) || 50)),
   };
 }
@@ -113,7 +115,7 @@ export function toBattleSkill(skill: SkillData): BattleSkill {
     damageType: normalizeSkillDamageType(skill.damage_type),
     element: String(skill.element || "none"),
     effects: skill.effects.map((effect) => ({ ...effect })),
-    triggerType: "active",
+    triggerType: normalizeBattleSkillTriggerType(skill.trigger_type),
     aiPriority: Math.max(0, Math.floor(skill.ai_priority || 0)),
   };
 }
@@ -271,6 +273,7 @@ export async function getCharacterBattleSkillData(
     .map((s) => ({
       skillId: String(s?.skillId ?? "").trim(),
       upgradeLevel: Math.max(0, Math.floor(toNumber(s?.upgradeLevel) ?? 0)),
+      triggerType: normalizeBattleSkillTriggerType(s?.triggerType),
     }))
     .filter((x) => x.skillId.length > 0);
 
@@ -329,6 +332,7 @@ export async function getCharacterBattleSkillData(
       damage_type: String(row.damage_type || "none"),
       element: String(row.element || "none"),
       effects: skillData.effects,
+      trigger_type: slot.triggerType,
       ai_priority: skillData.ai_priority,
     });
   }

--- a/server/src/services/characterTechniqueService.ts
+++ b/server/src/services/characterTechniqueService.ts
@@ -12,6 +12,7 @@ import { shouldValidateTechniqueLearnRealm } from './shared/techniqueLearnRule.j
 import { invalidateCharacterComputedCache } from './characterComputedService.js';
 import { getItemDefinitionById } from './staticConfigLoader.js';
 import {
+  getAllTechniqueLayersStatic,
   getItemMetaMap,
   getTechniqueLayerByTechniqueAndLayerStatic,
   getTechniqueLayersByTechniqueIdStatic,
@@ -28,6 +29,10 @@ import {
   loadCharacterAvailableSkillEntries,
   listCharacterAvailableSkillIdSet,
 } from './shared/characterAvailableSkills.js';
+import {
+  buildCharacterBattleSkillEntries,
+  canEquipBattleSkillToSlot,
+} from './shared/characterBattleSkillLoadout.js';
 
 // ============================================
 // 类型定义
@@ -771,6 +776,11 @@ class CharacterTechniqueService {
     }
 
     // 检查技能是否已装备在其他槽位
+    const skillDef = getSkillDefMap().get(skillId);
+    if (!skillDef || !canEquipBattleSkillToSlot(skillDef.trigger_type)) {
+      return { success: false, message: '被动技能不能装备到技能栏' };
+    }
+
     const existResult = await query(
       'SELECT slot_index FROM character_skill_slot WHERE character_id = $1 AND skill_id = $2',
       [characterId, skillId]
@@ -864,77 +874,44 @@ class CharacterTechniqueService {
   // ============================================
   async getBattleSkills(
     characterId: number
-  ): Promise<ServiceResult<{ skillId: string; upgradeLevel: number }[]>> {
-    const slotResult = await query(
-      'SELECT skill_id FROM character_skill_slot WHERE character_id = $1 ORDER BY slot_index',
-      [characterId]
-    );
+  ): Promise<ServiceResult<{ skillId: string; upgradeLevel: number; triggerType: 'active' | 'passive' }[]>> {
+    const [slotResult, techniqueRows] = await Promise.all([
+      query(
+        'SELECT skill_id FROM character_skill_slot WHERE character_id = $1 ORDER BY slot_index',
+        [characterId]
+      ),
+      query(
+        `
+          SELECT technique_id, current_layer, slot_type
+          FROM character_technique ct
+          WHERE ct.character_id = $1
+            AND ct.slot_type IS NOT NULL
+        `,
+        [characterId],
+      ),
+    ]);
 
-    if (slotResult.rows.length === 0) {
-      return { success: true, message: '无装备技能', data: [] };
-    }
-
-    const rawOrderedSkillIds = slotResult.rows
+    const slottedSkills = slotResult.rows
       .map((row) => (typeof row.skill_id === 'string' ? row.skill_id.trim() : ''))
       .filter((skillId): skillId is string => skillId.length > 0);
 
-    const availableSkillIds = await listCharacterAvailableSkillIdSet(characterId);
-    const orderedSkillIds = rawOrderedSkillIds.filter((skillId) => availableSkillIds.has(skillId));
+    const equippedTechniques = (techniqueRows.rows as Array<Record<string, unknown>>)
+      .map((row) => ({
+        techniqueId: typeof row.technique_id === 'string' ? row.technique_id.trim() : '',
+        currentLayer: Math.max(0, Math.floor(Number(row.current_layer ?? 0) || 0)),
+      }))
+      .filter((row) => row.techniqueId.length > 0 && row.currentLayer > 0);
 
-    if (orderedSkillIds.length === 0) {
-      return { success: true, message: '无装备技能', data: [] };
-    }
+    const skills = buildCharacterBattleSkillEntries({
+      equippedTechniques,
+      slottedSkills,
+      skillDefs: getSkillDefMap(),
+      layerRows: getAllTechniqueLayersStatic(),
+    });
 
-    const uniqueSkillIds = [...new Set(orderedSkillIds)];
-    const skillMap = getSkillDefMap();
-    const techniqueRows = await query(
-      `
-        SELECT technique_id, current_layer
-        FROM character_technique ct
-        WHERE ct.character_id = $1
-      `,
-      [characterId],
-    );
-
-    const upgradedSkillCountByTechniqueAndSkill = new Map<string, number>();
-    for (const row of techniqueRows.rows as Array<Record<string, unknown>>) {
-      const techniqueId = typeof row.technique_id === 'string' ? row.technique_id : '';
-      if (!techniqueId) continue;
-      const currentLayer = Math.max(0, Math.floor(Number(row.current_layer ?? 0) || 0));
-      if (currentLayer <= 0) continue;
-      const layerRows = getTechniqueLayersByTechniqueIdStatic(techniqueId).filter((entry) => entry.layer <= currentLayer);
-      for (const layerRow of layerRows) {
-        for (const upgradedSkillId of layerRow.upgradeSkillIds) {
-          const key = `${techniqueId}:${upgradedSkillId}`;
-          upgradedSkillCountByTechniqueAndSkill.set(key, (upgradedSkillCountByTechniqueAndSkill.get(key) ?? 0) + 1);
-        }
-      }
-    }
-
-    const upgradeLevelBySkillId = new Map<string, number>();
-    for (const skillId of uniqueSkillIds) {
-      const skillDef = skillMap.get(skillId);
-      if (!skillDef) continue;
-      if (skillDef.source_type !== 'technique' || typeof skillDef.source_id !== 'string' || !skillDef.source_id) {
-        upgradeLevelBySkillId.set(skillId, 0);
-        continue;
-      }
-      const key = `${skillDef.source_id}:${skillId}`;
-      const upgradeLevel = upgradedSkillCountByTechniqueAndSkill.get(key) ?? 0;
-      upgradeLevelBySkillId.set(skillId, upgradeLevel);
-    }
-
-    const skills = orderedSkillIds.map((skillId) => ({
-      skillId,
-      upgradeLevel: upgradeLevelBySkillId.get(skillId) ?? 0,
-    }));
-
-    return { success: true, message: '获取成功', data: skills };
+    return { success: true, message: '获取战斗技能成功', data: skills };
   }
 
-  // ============================================
-  // 14. 获取完整的角色功法状态（用于前端展示）（纯读，不加 @Transactional）
-  // ============================================
   async getCharacterTechniqueStatus(
     characterId: number
   ): Promise<ServiceResult<{

--- a/server/src/services/shared/characterBattleSkillLoadout.ts
+++ b/server/src/services/shared/characterBattleSkillLoadout.ts
@@ -1,0 +1,149 @@
+/**
+ * 角色战斗技能装载共享规则
+ *
+ * 作用（做什么 / 不做什么）：
+ * 1) 做什么：统一把“技能槽中的主动技能”与“已装备功法解锁的被动技能”合并成战斗可用技能列表。
+ * 2) 做什么：集中保留技能 triggerType，避免战斗层和功法服务层各自默认成 active。
+ * 3) 不做什么：不读数据库、不处理 UI 展示，也不直接构建 BattleSkill 运行时对象。
+ *
+ * 输入 / 输出：
+ * - 输入：已装备功法列表、技能槽列表、技能定义映射、功法层配置。
+ * - 输出：用于战斗装载的结构化技能条目（skillId / upgradeLevel / triggerType）。
+ *
+ * 数据流 / 状态流：
+ * - character_technique / character_skill_slot -> 本模块归一化 -> battle/shared/skills.ts 转成 SkillData
+ * - 被动技能不再依赖技能槽；只要功法已装备且层级已解锁，就会自动进入战斗装载结果。
+ *
+ * 关键边界条件与坑点：
+ * 1) 技能槽中的 passive 技能不能继续占用主动出手顺序，否则会出现“被动技能反复占回合释放”。
+ * 2) 被动技能需要按已装备功法的解锁层自动补入，但同一 skillId 只应补一次，避免重复触发。
+ */
+
+import type { SkillDefConfig } from '../staticConfigLoader.js';
+import type { TechniqueLayerStaticRow } from './techniqueUpgradeRules.js';
+
+export type BattleSkillTriggerType = 'active' | 'passive';
+
+export type EquippedTechniqueBattleSkillSource = {
+  techniqueId: string;
+  currentLayer: number;
+};
+
+export type SlottedBattleSkillSource = {
+  skillId: string;
+  slotIndex: number;
+};
+
+export type CharacterBattleSkillEntry = {
+  skillId: string;
+  upgradeLevel: number;
+  triggerType: BattleSkillTriggerType;
+};
+
+export const normalizeBattleSkillTriggerType = (
+  raw: string | null | undefined,
+): BattleSkillTriggerType => {
+  return String(raw || '').trim().toLowerCase() === 'passive' ? 'passive' : 'active';
+};
+
+export const canEquipBattleSkillToSlot = (
+  raw: string | null | undefined,
+): boolean => normalizeBattleSkillTriggerType(raw) === 'active';
+
+const buildTechniqueCurrentLayerMap = (
+  equippedTechniques: EquippedTechniqueBattleSkillSource[],
+): Map<string, number> => {
+  const currentLayerByTechnique = new Map<string, number>();
+  for (const entry of equippedTechniques) {
+    if (!entry.techniqueId) continue;
+    const nextLayer = Math.max(0, Math.floor(entry.currentLayer));
+    const currentLayer = currentLayerByTechnique.get(entry.techniqueId) ?? 0;
+    if (nextLayer > currentLayer) {
+      currentLayerByTechnique.set(entry.techniqueId, nextLayer);
+    }
+  }
+  return currentLayerByTechnique;
+};
+
+export const buildCharacterBattleSkillEntries = (params: {
+  equippedTechniques: EquippedTechniqueBattleSkillSource[];
+  slottedSkills: SlottedBattleSkillSource[];
+  skillDefs: ReadonlyMap<string, SkillDefConfig>;
+  layerRows: TechniqueLayerStaticRow[];
+}): CharacterBattleSkillEntry[] => {
+  const currentLayerByTechnique = buildTechniqueCurrentLayerMap(params.equippedTechniques);
+  if (currentLayerByTechnique.size <= 0) return [];
+
+  const unlockedSkillIdsByTechnique = new Map<string, Set<string>>();
+  const upgradedSkillCountByTechniqueAndSkill = new Map<string, number>();
+
+  for (const row of params.layerRows) {
+    const currentLayer = currentLayerByTechnique.get(row.techniqueId) ?? 0;
+    if (currentLayer <= 0 || row.layer > currentLayer) continue;
+
+    const unlockedSkillIds = unlockedSkillIdsByTechnique.get(row.techniqueId) ?? new Set<string>();
+    for (const skillId of row.unlockSkillIds) {
+      unlockedSkillIds.add(skillId);
+    }
+    unlockedSkillIdsByTechnique.set(row.techniqueId, unlockedSkillIds);
+
+    for (const skillId of row.upgradeSkillIds) {
+      const key = `${row.techniqueId}:${skillId}`;
+      upgradedSkillCountByTechniqueAndSkill.set(key, (upgradedSkillCountByTechniqueAndSkill.get(key) ?? 0) + 1);
+    }
+  }
+
+  const isUnlockedSkill = (skillId: string): boolean => {
+    for (const unlockedSkillIds of unlockedSkillIdsByTechnique.values()) {
+      if (unlockedSkillIds.has(skillId)) return true;
+    }
+    return false;
+  };
+
+  const resolveUpgradeLevel = (skillId: string): number => {
+    const skillDef = params.skillDefs.get(skillId);
+    if (!skillDef || skillDef.source_type !== 'technique' || typeof skillDef.source_id !== 'string' || !skillDef.source_id) {
+      return 0;
+    }
+    const key = `${skillDef.source_id}:${skillId}`;
+    return upgradedSkillCountByTechniqueAndSkill.get(key) ?? 0;
+  };
+
+  const activeEntries = [...params.slottedSkills]
+    .sort((left, right) => left.slotIndex - right.slotIndex)
+    .flatMap((entry) => {
+      const skillDef = params.skillDefs.get(entry.skillId);
+      if (!skillDef || !isUnlockedSkill(entry.skillId)) return [];
+      const triggerType = normalizeBattleSkillTriggerType(skillDef.trigger_type);
+      if (triggerType !== 'active') return [];
+      return [{
+        skillId: entry.skillId,
+        upgradeLevel: resolveUpgradeLevel(entry.skillId),
+        triggerType,
+      } satisfies CharacterBattleSkillEntry];
+    });
+
+  const passiveSkillIdSet = new Set<string>();
+  const passiveEntries: CharacterBattleSkillEntry[] = [];
+  for (const equippedTechnique of params.equippedTechniques) {
+    const unlockedSkillIds = unlockedSkillIdsByTechnique.get(equippedTechnique.techniqueId);
+    if (!unlockedSkillIds) continue;
+
+    for (const skillId of unlockedSkillIds) {
+      if (passiveSkillIdSet.has(skillId)) continue;
+      const skillDef = params.skillDefs.get(skillId);
+      if (!skillDef) continue;
+      const triggerType = normalizeBattleSkillTriggerType(skillDef.trigger_type);
+      if (triggerType !== 'passive') continue;
+
+      passiveSkillIdSet.add(skillId);
+      passiveEntries.push({
+        skillId,
+        upgradeLevel: resolveUpgradeLevel(skillId),
+        triggerType,
+      });
+    }
+  }
+
+  return [...activeEntries, ...passiveEntries];
+};

--- a/server/src/services/shared/techniqueGenerationCandidateCore.ts
+++ b/server/src/services/shared/techniqueGenerationCandidateCore.ts
@@ -117,6 +117,19 @@ const toDamageType = (raw: unknown): 'physical' | 'magic' | 'true' | null => {
   return null;
 };
 
+const toTriggerType = (raw: unknown, effects: unknown[]): 'active' | 'passive' => {
+  const text = asString(raw);
+  if (text === 'passive') return 'passive';
+  const hasAuraEffect = effects.some((entry) => {
+    if (!entry || typeof entry !== 'object' || Array.isArray(entry)) return false;
+    const effect = entry as Record<string, unknown>;
+    const effectType = asString(effect.type);
+    if (effectType !== 'buff' && effectType !== 'debuff') return false;
+    return asString(effect.buffKind) === 'aura';
+  });
+  return hasAuraEffect ? 'passive' : 'active';
+};
+
 const sanitizeTechniqueEffect = (raw: Record<string, unknown>): Record<string, unknown> => {
   const next = { ...raw };
   for (const field of TECHNIQUE_EFFECT_UNSUPPORTED_FIELDS) {
@@ -172,6 +185,7 @@ const sanitizeCandidateFromModel = (
     const row = rawSkill as Record<string, unknown>;
     const name = asString(row.name);
     if (!name) return [];
+    const effects = normalizeEffects(row.effects);
     return [{
       id: asString(row.id) || buildGeneratedSkillId(idx + 1),
       name,
@@ -187,8 +201,8 @@ const sanitizeCandidateFromModel = (
       targetCount: Math.floor(clamp(asNumber(row.targetCount, 1), 1, 6)),
       damageType: toDamageType(row.damageType),
       element: asString(row.element) || technique.attributeElement || 'none',
-      effects: normalizeEffects(row.effects),
-      triggerType: 'active',
+      effects,
+      triggerType: toTriggerType(row.triggerType, effects),
       aiPriority: Math.floor(clamp(asNumber(row.aiPriority, 50), 0, 100)),
       upgrades: Array.isArray(row.upgrades)
         ? row.upgrades.flatMap((entry) => {
@@ -383,9 +397,17 @@ export const validateTechniqueGenerationCandidate = (params: {
       return { success: false, message: 'AI结果技能效果为空', code: 'GENERATOR_INVALID' };
     }
 
+    let hasAuraEffect = false;
+
     for (const effect of skill.effects) {
       if (!effect || typeof effect !== 'object' || Array.isArray(effect)) {
         return { success: false, message: 'AI结果技能效果结构非法', code: 'GENERATOR_INVALID' };
+      }
+      const effectRow = effect as SkillEffect;
+      const effectType = typeof effectRow.type === 'string' ? effectRow.type.trim() : '';
+      const buffKind = typeof effectRow.buffKind === 'string' ? effectRow.buffKind.trim() : '';
+      if ((effectType === 'buff' || effectType === 'debuff') && buffKind === 'aura') {
+        hasAuraEffect = true;
       }
       const effectValidation = validateTechniqueSkillEffect(effect as SkillEffect);
       if (!effectValidation.success) {
@@ -394,6 +416,18 @@ export const validateTechniqueGenerationCandidate = (params: {
           message: `AI结果技能效果非法：${effectValidation.reason}`,
           code: 'GENERATOR_INVALID',
         };
+      }
+    }
+
+    if (hasAuraEffect) {
+      if (skill.triggerType !== 'passive') {
+        return { success: false, message: 'AI generated aura skill must use passive triggerType', code: 'GENERATOR_INVALID' };
+      }
+      if (skill.costLingqi !== 0 || skill.costLingqiRate !== 0 || skill.costQixue !== 0 || skill.costQixueRate !== 0 || skill.cooldown !== 0) {
+        return { success: false, message: 'AI generated aura skill must have zero cost and cooldown', code: 'GENERATOR_INVALID' };
+      }
+      if (skill.targetType !== 'self') {
+        return { success: false, message: 'AI generated aura skill must target self', code: 'GENERATOR_INVALID' };
       }
     }
 

--- a/server/src/services/shared/techniqueGenerationConstraints.ts
+++ b/server/src/services/shared/techniqueGenerationConstraints.ts
@@ -54,6 +54,11 @@ import {
   getTechniqueStructuredBuffCatalog,
   validateTechniqueStructuredBuffEffect,
 } from './techniqueStructuredBuffCatalog.js';
+import {
+  TECHNIQUE_PASSIVE_KEY_MEANING_MAP,
+  TECHNIQUE_PASSIVE_KEYS,
+  TECHNIQUE_PASSIVE_MODE_BY_KEY,
+} from './characterAttrRegistry.js';
 
 export const GENERATED_TECHNIQUE_TYPE_LIST = ['武技', '心法', '法诀', '身法', '辅修'] as const;
 export type GeneratedTechniqueType = (typeof GENERATED_TECHNIQUE_TYPE_LIST)[number];
@@ -92,68 +97,9 @@ export const isGeneratedTechniqueType = (raw: unknown): raw is GeneratedTechniqu
   return typeof raw === 'string' && GENERATED_TECHNIQUE_TYPE_LIST.includes(raw as GeneratedTechniqueType);
 };
 
-export const TECHNIQUE_PASSIVE_KEY_MEANING_MAP: Record<string, string> = {
-  wugong: '物理攻击（百分比加成）',
-  fagong: '法术攻击（百分比加成）',
-  wufang: '物理防御（百分比加成）',
-  fafang: '法术防御（百分比加成）',
-  max_qixue: '最大气血（百分比加成）',
-  max_lingqi: '最大灵气（固定值加成）',
-  mingzhong: '命中率（加算百分比）',
-  shanbi: '闪避率（加算百分比）',
-  zhaojia: '招架率（加算百分比）',
-  baoji: '暴击率（加算百分比）',
-  baoshang: '暴击伤害倍率（加算百分比）',
-  jianbaoshang: '暴击伤害减免（加算百分比）',
-  kangbao: '抗暴率（加算百分比）',
-  zengshang: '增伤（加算百分比）',
-  zhiliao: '治疗加成（加算百分比）',
-  jianliao: '受疗减免（加算百分比）',
-  xixue: '吸血比例（加算百分比）',
-  lengque: '冷却缩减（加算百分比）',
-  sudu: '速度（固定值加成）',
-  kongzhi_kangxing: '控制抗性（加算百分比）',
-  jin_kangxing: '金系抗性（加算百分比）',
-  mu_kangxing: '木系抗性（加算百分比）',
-  shui_kangxing: '水系抗性（加算百分比）',
-  huo_kangxing: '火系抗性（加算百分比）',
-  tu_kangxing: '土系抗性（加算百分比）',
-  qixue_huifu: '每回合气血恢复（固定值加成）',
-  lingqi_huifu: '每回合灵气恢复（固定值加成）',
-};
-
-export const SUPPORTED_TECHNIQUE_PASSIVE_KEYS = Object.freeze(Object.keys(TECHNIQUE_PASSIVE_KEY_MEANING_MAP));
+export const SUPPORTED_TECHNIQUE_PASSIVE_KEYS = TECHNIQUE_PASSIVE_KEYS;
 export const SUPPORTED_TECHNIQUE_PASSIVE_KEY_SET = new Set<string>(SUPPORTED_TECHNIQUE_PASSIVE_KEYS);
-
-const TECHNIQUE_PASSIVE_MODE_BY_KEY: Record<string, TechniquePassiveMode> = {
-  wugong: 'percent',
-  fagong: 'percent',
-  wufang: 'percent',
-  fafang: 'percent',
-  max_qixue: 'percent',
-  max_lingqi: 'flat',
-  mingzhong: 'percent',
-  shanbi: 'percent',
-  zhaojia: 'percent',
-  baoji: 'percent',
-  baoshang: 'percent',
-  jianbaoshang: 'percent',
-  kangbao: 'percent',
-  zengshang: 'percent',
-  zhiliao: 'percent',
-  jianliao: 'percent',
-  xixue: 'percent',
-  lengque: 'percent',
-  sudu: 'flat',
-  kongzhi_kangxing: 'percent',
-  jin_kangxing: 'percent',
-  mu_kangxing: 'percent',
-  shui_kangxing: 'percent',
-  huo_kangxing: 'percent',
-  tu_kangxing: 'percent',
-  qixue_huifu: 'flat',
-  lingqi_huifu: 'flat',
-};
+export { TECHNIQUE_PASSIVE_KEY_MEANING_MAP };
 
 /**
  * 功法被动预算共享规则
@@ -196,12 +142,13 @@ export const getTechniquePassiveValueConstraint = (
   quality: GeneratedTechniqueQuality,
 ): TechniquePassiveValueConstraint | null => {
   const mode = TECHNIQUE_PASSIVE_MODE_BY_KEY[key];
-  if (mode !== 'percent' && mode !== 'flat') {
+  if (mode !== 'percent' && mode !== 'flat' && mode !== 'multiply') {
     return null;
   }
-  const baseConstraint = TECHNIQUE_PASSIVE_DEFAULT_CONSTRAINTS_BY_MODE[mode][quality];
+  const normalizedMode: TechniquePassiveMode = mode === 'multiply' ? 'percent' : mode;
+  const baseConstraint = TECHNIQUE_PASSIVE_DEFAULT_CONSTRAINTS_BY_MODE[normalizedMode][quality];
   return {
-    mode,
+    mode: normalizedMode,
     maxPerLayer: baseConstraint.maxPerLayer,
     maxTotal: baseConstraint.maxTotal,
   };
@@ -240,7 +187,7 @@ export const buildTechniquePassiveValueGuideByKey = (
 export const TECHNIQUE_PASSIVE_ENTRY_POOL = Object.freeze(
   SUPPORTED_TECHNIQUE_PASSIVE_KEYS.map((key) => ({
     key,
-    mode: TECHNIQUE_PASSIVE_MODE_BY_KEY[key],
+    mode: TECHNIQUE_PASSIVE_MODE_BY_KEY[key] === 'multiply' ? 'percent' : TECHNIQUE_PASSIVE_MODE_BY_KEY[key],
   })),
 );
 
@@ -507,7 +454,7 @@ export const TECHNIQUE_PROMPT_FIELD_SEMANTICS = {
     damageType: '伤害类型 physical/magic/true/null',
     element: '技能元素，必须在 elementEnum 中',
     effects: '技能效果数组，按 effectSchemaByType 生成',
-    triggerType: '触发类型，固定 active',
+    triggerType: 'trigger type: normal skills use active, aura passives use passive',
     aiPriority: 'AI 施放优先级，范围见 numericRanges.skill.aiPriority，越高越优先',
     upgrades: '高层强化配置数组；可为空数组；必须符合 upgradeSchema',
   },
@@ -1058,7 +1005,7 @@ export const buildTechniqueGenerationResponseFormat = (params: {
                 },
                 minItems: 1,
               },
-              triggerType: { type: 'string', enum: ['active'] },
+              triggerType: { type: 'string', enum: ['active', 'passive'] },
               aiPriority: { type: 'integer', minimum: 0, maximum: 100 },
               // upgrades 内部结构由 prompt 约束 + 后端 validate 保证；只要求每个 upgrade 有 layer 字段，其余字段自由输出
               upgrades: {

--- a/server/src/services/techniqueGenerationService.ts
+++ b/server/src/services/techniqueGenerationService.ts
@@ -105,7 +105,7 @@ export type TechniqueGenerationCandidate = {
     damageType: 'physical' | 'magic' | 'true' | null;
     element: string;
     effects: unknown[];
-    triggerType: 'active';
+    triggerType: 'active' | 'passive';
     aiPriority: number;
     upgrades: TechniqueSkillUpgradeEntry[];
   }>;


### PR DESCRIPTION
问题：自研功法里的 passive 技能在进入战斗时丢失 triggerType，并被统一当成 active。结果是 aura 光环不会开场自动生效，反而会进入技能轮转，占用角色回合反复释放；同时被动技能还依赖技能栏顺序，放在后面时轮到前完全不生效。

修复：1) 保留并传递 trigger_type 到 BattleSkill；2) 抽取统一的战斗技能装载逻辑，主动技能仅从技能栏读取，被动技能从已装备功法自动补入；3) 服务端禁止把 passive 技能装备到技能栏；4) 生成约束允许 passive，并对 aura 技能强制 passive/self/零消耗零冷却；5) 增加装载与战斗流测试。

说明：这次修的是代码链路和后续生成逻辑。历史上已经错误生成并落库为 active 的 aura 技能，仍可能需要额外做数据库巡检与修正。